### PR TITLE
add `typeCreated` property to action creators

### DIFF
--- a/src/actionCreators.ts
+++ b/src/actionCreators.ts
@@ -13,11 +13,13 @@ export interface Action<TPayload> extends Redux.Action {
 export interface CreateAction<TPayload> {
     (payload?: TPayload): Action<TPayload>;
     matchAction(action: Redux.Action): action is Action<TPayload>;
+    typeCreated: string;
 }
 
 export const createAction = <TPayload>(actionName: string): CreateAction<TPayload> => {
     let create: any = <TPayload>(payload?: TPayload) => ({ type: actionName, payload: payload });
     create.matchAction = <TPayLoad>(action: Redux.Action): action is Action<TPayload> => action.type === actionName;
+    create.typeCreated = actionName;
     return <CreateAction<TPayload>> create;
 }
 
@@ -30,6 +32,7 @@ export interface CreatePromiseAction<TParms> {
     matchOnStart(action: Redux.Action): action is PromiseAction;
     matchOnEnd(action: Redux.Action): action is PromiseAction;
     matchOnError(action: Redux.Action): action is PromiseAction;
+    typeCreated: string;
 }
 
 /**
@@ -82,6 +85,8 @@ export const createPromiseAction = <TParms, TResult>(
     create.matchOnError = <TPayLoad>(action: Redux.Action): action is PromiseAction =>
         (<PromiseAction>action).promiseActionType === actionName &&
         (<PromiseAction>action).promiseActionEvent === 'OnError';
+
+    create.typeCreated = actionName;
 
     return <CreatePromiseAction<TParms>> create;
 }

--- a/test/test.test.ts
+++ b/test/test.test.ts
@@ -24,6 +24,22 @@ describe('Action Creators', () => {
         expect(simpleAction.matchAction(act2)).toEqual(false);
     })
 
+    it('createAction.typeCreated', () => {
+        const simpleAction = lib.createAction<string>('TEST_ACTION');
+
+        expect(simpleAction.typeCreated).toEqual('TEST_ACTION');
+    })
+
+    it('createPromiseAction.typeCreated', () => {
+        const resultAction = lib.createAction<string>('RESULT_ACTION');
+        const promiseAction = lib.createPromiseAction<string, string>(
+            'TEST_PROMISE_ACTION',
+            (value) => Promise.resolve('value'),
+            resultAction);
+
+        expect(promiseAction.typeCreated).toEqual('TEST_PROMISE_ACTION');
+    })
+
 });
 
 


### PR DESCRIPTION
this feature is useful for tracking promise actions by type

I'm using it like this:

## reducer to track what promise actions are in progress:
```
import { Reducer, Action } from 'redux';
import { PromiseAction } from 'redux-helper/dist/actionCreators';

const isPromiseActionEventWaiting = (event: string) => {
  switch (event) {
    case 'OnStart':
      return true;
    default:
      return false;
  }
};

const defaultState: IWaitingState = {
};

const reducer: Reducer<IWaitingState> = (state = defaultState, action: Action) => {

  if (action.type === 'LOAD_MESSAGE') {
    const promiseAction = action as PromiseAction;
    return {
      ...state,
      [promiseAction.promiseActionType]: isPromiseActionEventWaiting(promiseAction.promiseActionEvent),
    };
  }

  return state;
};

export default reducer;
```

## component mapStateToProps
In connected components I can see which promise actions are in progress and put up wait cursors etc, e.g.:
```
const mapStateToProps = (state: IAppState): IMappedProps => ({
    submitting: state.waiting[actionCreatorName.typeCreated],
});
```