### PR TITLE
added promiseActionParams to promise lifecycle actions

### DIFF
--- a/src/actionCreators.ts
+++ b/src/actionCreators.ts
@@ -35,18 +35,18 @@ export interface Action<TPayload> extends Redux.Action {
 export interface CreateAction<TPayload> {
     (payload?: TPayload): Action<TPayload>;
     matchAction(action: Redux.Action): action is Action<TPayload>;
-    matchAsLinkedPromiseAction(action: Redux.Action): action is PromiseAction;
+    matchAsLinkedPromiseAction(action: Redux.Action): action is PromiseAction<TPayload>;
     type: string;
 }
 
 export const createAction = <TPayload>(type: string): CreateAction<TPayload> => {
-    let create: any = <TPayload>(payload?: TPayload) => ({ type: type, payload: payload });
+    let create: any = <TPayload>(payload?: TPayload) => ({ type, payload });
 
     create.matchAction = <TPayLoad>(action: Redux.Action): action is Action<TPayload> => {
         return action.type === type
     };
 
-    create.matchAsLinkedPromiseAction = <TPayLoad>(action: Redux.Action): action is PromiseAction => {
+    create.matchAsLinkedPromiseAction = <TPayLoad>(action: Redux.Action): action is PromiseAction<TPayload> => {
         return action.type === type && (<PromiseAction>action).promiseActionType != null;
     };
 
@@ -57,12 +57,12 @@ export const createAction = <TPayload>(type: string): CreateAction<TPayload> => 
 /**
  * Promise Action Interface and Creator
  */
-export interface CreatePromiseAction<TParms> {
-    (parms?: TParms): Redux.Action;
-    matchAction(action: Redux.Action): action is PromiseAction;
-    matchOnStart(action: Redux.Action): action is PromiseAction;
-    matchOnEnd(action: Redux.Action): action is PromiseAction;
-    matchOnError(action: Redux.Action): action is PromiseAction;
+export interface CreatePromiseAction<TParams = undefined> {
+    (params?: TParams): Redux.Action;
+    matchAction(action: Redux.Action): action is PromiseAction<TParams>;
+    matchOnStart(action: Redux.Action): action is PromiseAction<TParams>;
+    matchOnEnd(action: Redux.Action): action is PromiseAction<TParams>;
+    matchOnError(action: Redux.Action): action is PromiseAction<TParams>;
     type: string;
 }
 
@@ -75,14 +75,15 @@ export interface CreatePromiseActionOptions {
     message?: string
 }
 
-export interface IPromiseAction {
+export interface IPromiseAction<TParams = undefined> {
     promiseActionType: string;
     promiseActionEvent: 'OnStart' | 'OnEnd' | 'OnError';
     promiseActionMessage?: string,
     promiseActionError?: any;
+    promiseActionParams: TParams;
 }
 
-export interface PromiseAction extends IPromiseAction, Redux.Action { }
+export interface PromiseAction<TParams = undefined> extends IPromiseAction<TParams>, Redux.Action { }
 
 export const createPromiseAction = <TParms, TResult>(
     type: string,
@@ -102,18 +103,18 @@ export const createPromiseAction = <TParms, TResult>(
         }
     )
 
-    create.matchAction = <TPayLoad>(action: Redux.Action): action is PromiseAction =>
+    create.matchAction = <TPayLoad>(action: Redux.Action): action is PromiseAction<TParms> =>
         (<PromiseAction>action).promiseActionType === type;
 
-    create.matchOnStart = <TPayLoad>(action: Redux.Action): action is PromiseAction =>
+    create.matchOnStart = <TPayLoad>(action: Redux.Action): action is PromiseAction<TParms> =>
         (<PromiseAction>action).promiseActionType === type &&
         (<PromiseAction>action).promiseActionEvent === 'OnStart';
 
-    create.matchOnEnd = <TPayLoad>(action: Redux.Action): action is PromiseAction =>
+    create.matchOnEnd = <TPayLoad>(action: Redux.Action): action is PromiseAction<TParms> =>
         (<PromiseAction>action).promiseActionType === type &&
         (<PromiseAction>action).promiseActionEvent === 'OnEnd';
 
-    create.matchOnError = <TPayLoad>(action: Redux.Action): action is PromiseAction =>
+    create.matchOnError = <TPayLoad>(action: Redux.Action): action is PromiseAction<TParms> =>
         (<PromiseAction>action).promiseActionType === type &&
         (<PromiseAction>action).promiseActionEvent === 'OnError';
 

--- a/src/checkedPromiseMiddleware.ts
+++ b/src/checkedPromiseMiddleware.ts
@@ -72,19 +72,21 @@ const checkedPromiseMiddleware = (options?: CheckedPromiseMiddlewareOptions) => 
                 promiseActionType: action.type,
                 promiseActionEvent: 'OnStart',
                 promiseActionMessage: message,
+                promiseActionParams: promiseParms,
             });
             dispatch(actStart);
         }
     }
 
     return promise.then(
-        response => {
+        (response: any) => {
             if (enableProgress && _validFunction(opts.onEnd)) {
                 const actEnd = opts.onEnd();
                 if (_validAction(actEnd)) {
                     Object.assign(actEnd, <IPromiseAction>{
                         promiseActionType: action.type,
-                        promiseActionEvent: 'OnEnd'
+                        promiseActionEvent: 'OnEnd',
+                        promiseActionParams: promiseParms,
                     });
                     dispatch(actEnd);
                 }
@@ -93,14 +95,15 @@ const checkedPromiseMiddleware = (options?: CheckedPromiseMiddlewareOptions) => 
             const actResult = resultAction(response, promiseParms);
             dispatch(actResult);
         },
-        error => {
+        (error: any) => {
             if (_validFunction(opts.onError)) {
                 const actError = opts.onError(error);
                 if (_validAction(actError)) {
                     Object.assign(actError, <IPromiseAction>{
                         promiseActionType: action.type,
                         promiseActionEvent: 'OnError',
-                        promiseActionError: error
+                        promiseActionError: error,
+                        promiseActionParams: promiseParms,
                     });
                     dispatch(actError);
                 }

--- a/test/lifecycle.test.ts
+++ b/test/lifecycle.test.ts
@@ -1,0 +1,134 @@
+import * as mocha from "mocha";
+import * as expect from "expect";
+import * as lib from "../src";
+import { createStore, applyMiddleware, Reducer, Store } from "redux";
+
+export const promiseActionStart = lib.createAction<string | undefined>(
+  "PROMISE_ACTION_START"
+);
+export const promiseActionEnd = lib.createAction("PROMISE_ACTION_END");
+export const promiseActionError = lib.createAction<{ message?: string }>(
+  "PROMISE_ACTION_ERROR"
+);
+
+const opts: lib.CheckedPromiseMiddlewareOptions = {
+  onStart: promiseActionStart,
+  onEnd: promiseActionEnd,
+  onError: promiseActionError
+};
+
+interface IAppState {
+  onStartParams?: string;
+  onEndParams?: string;
+  onErrorParams?: any;
+  result?: string;
+}
+
+const initialState: IAppState = {};
+
+const resultAction = lib.createAction<string>("RESULT_ACTION1");
+
+const error = new Error("error1");
+
+const promiseAction = lib.createPromiseAction<string, string>(
+  "PROMISE_ACTION1",
+  arg => {
+    return arg !== "FORCEERROR"
+      ? Promise.resolve((arg || "").toUpperCase())
+      : Promise.reject(error);
+  },
+  resultAction
+);
+
+const reducer: Reducer<IAppState> = (
+  state = initialState,
+  action: lib.Action<any>
+) => {
+  if (resultAction.matchAction(action)) {
+    return {
+      ...state,
+      result: action.payload
+    };
+  }
+  if (promiseAction.matchOnStart(action)) {
+    return {
+      ...state,
+      onStartParams: action.promiseActionParams
+    };
+  } else if (promiseAction.matchOnEnd(action)) {
+    return {
+      ...state,
+      onEndParams: action.promiseActionParams
+    };
+  } else if (promiseAction.matchOnError(action)) {
+    return {
+      ...state,
+      onErrorParams: action.promiseActionParams
+    };
+  }
+  return state;
+};
+
+describe("lifecycle (promise actions)", () => {
+  let store: Store<IAppState>;
+
+  const recreateStore = () => {
+    store = createStore<IAppState>(
+      reducer,
+      applyMiddleware(lib.checkedPromiseMiddleware(opts))
+    );
+  };
+
+  describe("basic lifecycle", () => {
+    let promiseActionParams: string;
+
+    describe("successful round trip", () => {
+      before(() => {
+        recreateStore();
+        promiseActionParams = "hi";
+
+        store.dispatch(promiseAction(promiseActionParams));
+      });
+
+      it("state.result should match result", () => {
+        expect(store.getState().result).toBe(promiseActionParams.toUpperCase());
+      });
+
+      it("state.onStartParams should match action parameters", () => {
+        expect(store.getState().onStartParams).toBe(promiseActionParams);
+      });
+
+      it("state.onEndParameters should match action parameters", () => {
+        expect(store.getState().onEndParams).toBe(promiseActionParams);
+      });
+
+      it("state.onErrorParams should be undefined", () => {
+        expect(store.getState().onErrorParams).toBe(undefined);
+      });
+    });
+
+    describe("error in promise", () => {
+      before(() => {
+        promiseActionParams = "FORCEERROR";
+        recreateStore();
+        store.dispatch(promiseAction(promiseActionParams));
+      });
+
+      it("state.result should be undefined", () => {
+        expect(store.getState().result).toBe(undefined);
+      });
+
+      it("state.onStartParams should match action params", () => {
+        expect(store.getState().onStartParams).toBe(promiseActionParams);
+      });
+
+      it("state.onEndParameters should be undefined", () => {
+        expect(store.getState().onEndParams).toBe(undefined);
+      });
+
+      it("state.onErrorParameters should be action params", () => {
+        expect(store.getState().onErrorParams).toBe(promiseActionParams);
+      });
+    });
+  });
+});


### PR DESCRIPTION
I sometimes want to find out the arguments to the `createPromiseAction` in one or more of the lifecycle matchers in a reducer. E.g. `promiseAction.matchOnStart(action)`.

This PR adds `.promiseActionParams` property to the action that dispatched for each of the stages in a promise action lifecycle. Strongly typed of course.
