### PR TITLE
WIP: Better typing for when no payload on an action creator

### DIFF
--- a/src/actionCreators.ts
+++ b/src/actionCreators.ts
@@ -33,7 +33,8 @@ export interface Action<TPayload> extends Redux.Action {
  * Plain Action creator
  */
 export interface CreateAction<TPayload> {
-    (payload?: TPayload): Action<TPayload>;
+    (): Redux.Action;
+    (payload: TPayload): Action<TPayload>;
     matchAction(action: Redux.Action): action is Action<TPayload>;
     matchAsLinkedPromiseAction(action: Redux.Action): action is PromiseAction<TPayload>;
     type: string;
@@ -51,14 +52,15 @@ export const createAction = <TPayload>(type: string): CreateAction<TPayload> => 
     };
 
     create.type = type;
-    return <CreateAction<TPayload>>create;
+    return create;
 }
 
 /**
  * Promise Action Interface and Creator
  */
 export interface CreatePromiseAction<TParams = undefined> {
-    (params?: TParams): Redux.Action;
+    (): Redux.Action;
+    (payload: TParams): Redux.Action;
     matchAction(action: Redux.Action): action is PromiseAction<TParams>;
     matchOnStart(action: Redux.Action): action is PromiseAction<TParams>;
     matchOnEnd(action: Redux.Action): action is PromiseAction<TParams>;
@@ -87,7 +89,7 @@ export interface PromiseAction<TParams = undefined> extends IPromiseAction<TPara
 
 export const createPromiseAction = <TParms, TResult>(
     type: string,
-    promise: (parms: TParms | undefined) => Promise<TResult>,
+    promise: (parms?: TParms) => Promise<TResult>,
     resultAction: (res: TResult, parms?: TParms) => any,
     options?: CreatePromiseActionOptions): CreatePromiseAction<TParms> => {
 
@@ -119,7 +121,7 @@ export const createPromiseAction = <TParms, TResult>(
         (<PromiseAction>action).promiseActionEvent === 'OnError';
 
     create.type = type;
-    return <CreatePromiseAction<TParms>>create;
+    return create;
 }
 
 export function createPromiseThunkAction<TParms, TResult>(

--- a/test/test.test.ts
+++ b/test/test.test.ts
@@ -25,6 +25,7 @@ import * as  expect from 'expect';
 import * as lib from '../src';
 
 describe('Action Creators', () => {
+
     it('createAtion', () => {
         const simpleAction = lib.createAction<string>('TEST_ACTION');
 
@@ -41,6 +42,7 @@ describe('Action Creators', () => {
         const act2 = { type: 'TEST_ANOTHER_ACTION', payload: 'test payload' };
 
         const simpleAction = lib.createAction<string>('TEST_ACTION');
+        simpleAction()
 
         expect(simpleAction.matchAction(act1)).toEqual(true);
         expect(simpleAction.matchAction(act2)).toEqual(false);
@@ -60,6 +62,14 @@ describe('Action Creators', () => {
 
         expect(promiseAction.type).toEqual('TEST_PROMISE_ACTION');
     })
+
+    it('createAction with no params', () => {
+        const actionCreator = lib.createAction('TEST_ACTION');
+        const action = actionCreator();
+        expect(action.type).toBe('TEST_ACTION');
+        // expect(action.payload).toNotBeInType()
+        // no action.payload in type of action--can't runtime test that!
+    });
 });
 
 


### PR DESCRIPTION
Something that has always bugged me but I've not found a way to solve it yet is that if there is a payload for `createAction` it isn't enforced in the type, so you can send in null.

```
const myAction = createAction<string>('MY_ACTION');

myAction(); // compiles but shouldn't
```

The second part is that if you don't specify an argument for your action creator, in `matchAction` you still have a `payload`.

```
const myAction = createAction<string>('MY_ACTION');
if (myAction.matchAction(action)) {
   // action.payload is in the type, but is undefined
}
```

> In this PR I solve the second issue only, that is `action` will not have a `payload` if it isn't defined on `createAction()` call.

EDIT: Actually this only fixes the type of the return value from `createAction()`.

Marking it WIP as not a lot of value yet.