### PR TITLE
add support for no payload, verify payload provided when expected

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2631,9 +2631,9 @@
       }
     },
     "make-error": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.0.tgz",
-      "integrity": "sha1-Uq06M5zPEM5itAQLcI/nByRLi5Y=",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.4.tgz",
+      "integrity": "sha512-0Dab5btKVPhibSalc9QGXb559ED7G7iLjFXBaj9Wq8O3vorueR5K5jaE3hkG6ZQINyhA/JgG6Qk4qdFQjsYV6g==",
       "dev": true
     },
     "micromatch": {
@@ -3360,36 +3360,42 @@
       "dev": true,
       "requires": {
         "arrify": "1.0.1",
-        "chalk": "2.3.0",
+        "chalk": "2.3.2",
         "diff": "3.2.0",
-        "make-error": "1.3.0",
+        "make-error": "1.3.4",
         "minimist": "1.2.0",
         "mkdirp": "0.5.1",
         "source-map-support": "0.4.18",
         "tsconfig": "6.0.0",
-        "v8flags": "3.0.1",
+        "v8flags": "3.0.2",
         "yn": "2.0.0"
       },
       "dependencies": {
         "ansi-styles": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
             "color-convert": "1.9.0"
           }
         },
         "chalk": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+          "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.0",
+            "ansi-styles": "3.2.1",
             "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
+            "supports-color": "5.3.0"
           }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
         },
         "minimist": {
           "version": "1.2.0",
@@ -3398,18 +3404,18 @@
           "dev": true
         },
         "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+          "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
           "dev": true,
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "3.0.0"
           }
         },
         "v8flags": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.0.1.tgz",
-          "integrity": "sha1-3Oj8N5wX2fLJ6e142JzgAFKxt2s=",
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.0.2.tgz",
+          "integrity": "sha512-6sgSKoFw1UpUPd3cFdF7QGnrH6tDeBgW1F3v9gy8gLY0mlbiBXq8soy8aQpY6xeeCjH5K+JvC62Acp7gtl7wWA==",
           "dev": true,
           "requires": {
             "homedir-polyfill": "1.0.1"
@@ -3451,6 +3457,12 @@
       "requires": {
         "prelude-ls": "1.1.2"
       }
+    },
+    "typescript": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.8.1.tgz",
+      "integrity": "sha512-Ao/f6d/4EPLq0YwzsQz8iXflezpTkQzqAyenTiw4kCUGr1uPiFLC3+fZ+gMZz6eeI/qdRUqvC+HxIJzUAzEFdg==",
+      "dev": true
     },
     "user-home": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-helper",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "license": "MIT",
   "description": "Redux reducer and action helper",
   "repository": "https://github.com/vgmr/redux-helper/",
@@ -23,7 +23,8 @@
     "mocha": "^4.0.1",
     "redux-thunk": "^2.2.0",
     "rimraf": "^2.6.2",
-    "ts-node": "^3.3.0"
+    "ts-node": "^3.3.0",
+    "typescript": "^2.8.1"
   },
   "dependencies": {
     "redux": "^3.7.2"

--- a/src/actionCreators.ts
+++ b/src/actionCreators.ts
@@ -24,8 +24,8 @@ import * as Redux from 'redux';
 import { CreateAction, Action, CreatePromiseAction, CreatePromiseActionOptions, PromiseAction, LinkedPromiseAction, PromiseActionInstance } from './index';
 
 // #region Action
-export const createAction = <TPayload>(type: string): CreateAction<TPayload> => {
-    let create: any = <TPayload>(payload?: TPayload) => ({ type: type, payload: payload });
+export const createAction = <TPayload = undefined>(type: string): CreateAction<TPayload> => {
+    let create: any = <TPayload>(payload?: TPayload) => payload && { type, payload } || { type };
 
     create.matchAction = <TPayLoad>(action: Redux.Action): action is Action<TPayload> => {
         return action.type === type

--- a/src/actionTypes.ts
+++ b/src/actionTypes.ts
@@ -52,11 +52,12 @@ export interface PromiseActionInstance<TParams> extends PromiseAction {
     promiseActionParams: TParams;
 }
 
+export type Create<TPayload> = TPayload extends undefined ? () => Redux.Action : (payload: TPayload) => Action<TPayload>;
+
 /**
  * Plain Action creator
  */
-export interface CreateAction<TPayload> {
-    (payload?: TPayload): Action<TPayload>;
+export type CreateAction<TPayload = undefined> = Create<TPayload> & {
     matchAction(action: Redux.Action): action is Action<TPayload>;
     matchAsLinkedPromiseAction<TParams>(action: Redux.Action): action is Action<TPayload> & PromiseActionInstance<TParams>;
     matchAsLinkedPromiseAction<TParams>(action: Redux.Action, promiseAction: CreatePromiseAction<TParams>): action is Action<TPayload> & PromiseActionInstance<TParams>;

--- a/test/creators.test.ts
+++ b/test/creators.test.ts
@@ -22,39 +22,65 @@
 
 import * as mocha from 'mocha';
 import * as expect from 'expect';
-import * as lib from "../src";
+import * as lib from '../src';
 
 describe('Action Creators', () => {
-
+  describe('with payload', () => {
     it('createAction', () => {
-        const simpleAction = lib.createAction<string>('TEST_ACTION');
-        const actRes = simpleAction('test payload');
-        expect(actRes.type).toEqual('TEST_ACTION');
-        expect(actRes.payload).toEqual('test payload');
-    })
+      const simpleAction = lib.createAction<string>('TEST_ACTION');
+      const actRes = simpleAction('test payload');
+      expect(actRes.type).toEqual('TEST_ACTION');
+      expect(actRes.payload).toEqual('test payload');
+    });
 
-    it('createAtion.matchAction', () => {
-        const act1 = { type: 'TEST_ACTION', payload: 'test payload' };
-        const act2 = { type: 'TEST_ANOTHER_ACTION', payload: 'test payload' };
+    it('createAction.matchAction', () => {
+      const act1 = { type: 'TEST_ACTION', payload: 'test payload' };
+      const act2 = { type: 'TEST_ANOTHER_ACTION', payload: 'test payload' };
 
-        const simpleAction = lib.createAction<string>('TEST_ACTION');
+      const simpleAction = lib.createAction<string>('TEST_ACTION');
 
-        expect(simpleAction.matchAction(act1)).toEqual(true);
-        expect(simpleAction.matchAction(act2)).toEqual(false);
-    })
+      expect(simpleAction.matchAction(act1)).toEqual(true);
+      expect(simpleAction.matchAction(act2)).toEqual(false);
+    });
 
     it('createAction.type', () => {
-        const simpleAction = lib.createAction<string>('TEST_ACTION');
-        expect(simpleAction.type).toEqual('TEST_ACTION');
-    })
+      const simpleAction = lib.createAction<string>('TEST_ACTION');
+      expect(simpleAction.type).toEqual('TEST_ACTION');
+    });
 
     it('createPromiseAction.type', () => {
-        const resultAction = lib.createAction<string>('RESULT_ACTION');
-        const promiseAction = lib.createPromiseAction<string, string>(
-            'TEST_PROMISE_ACTION',
-            (value) => Promise.resolve('value'),
-            resultAction);
+      const resultAction = lib.createAction<string>('RESULT_ACTION');
+      const promiseAction = lib.createPromiseAction<string, string>(
+        'TEST_PROMISE_ACTION',
+        value => Promise.resolve('value'),
+        resultAction,
+      );
 
-        expect(promiseAction.type).toEqual('TEST_PROMISE_ACTION');
-    })
+      expect(promiseAction.type).toEqual('TEST_PROMISE_ACTION');
+    });
+  });
+
+  describe('without payload', () => {
+    it('createAction', () => {
+      const simpleAction = lib.createAction('TEST_ACTION');
+      const actRes = simpleAction();
+      expect(actRes.type).toEqual('TEST_ACTION');
+    });
+
+    it('createAction.matchAction', () => {
+      const act1 = { type: 'TEST_ACTION' };
+      const act2 = { type: 'TEST_ANOTHER_ACTION' };
+
+      const simpleAction = lib.createAction('TEST_ACTION');
+
+      expect(simpleAction.matchAction(act1)).toEqual(true);
+      expect(simpleAction.matchAction(act2)).toEqual(false);
+    });
+
+    it('createAction.type', () => {
+      const simpleAction = lib.createAction('TEST_ACTION');
+      expect(simpleAction.type).toEqual('TEST_ACTION');
+    });
+
+  });
 });


### PR DESCRIPTION
on synchronous action only
using typescript 2.8 conditional types

means you can do 
``` 
const creator = createAction("TYPE")`; // (no payload typed param)
dispatch(creator())
```

and also if you do specify a type parameter, it won't let you put in null/undefined (a source of bugs in redux-helper for me);
```
const creator = createAction<string>("TYPE");
dispatch(creator('HI')); // good
dispatch(creator()); // compile error
dispatch(creator(undefined)); // compile error if strictNullChecks turned on
```

would like to see this on promise actions too but a bit more to it